### PR TITLE
Fix attachment download path

### DIFF
--- a/app/views/attachments/pdf_view.html.erb
+++ b/app/views/attachments/pdf_view.html.erb
@@ -4,7 +4,7 @@
 
 <div class="pdf-preview-container" style="height: 80vh;">
   <iframe
-    src="<%= asset_path('pdfjs/web/viewer.html', plugin: 'redmine_pdf_preview_kaizen2b') %>?file=<%= CGI.escape(download_attachments_path(id: @attachment.id)) %>"
+    src="<%= asset_path('pdfjs/web/viewer.html', plugin: 'redmine_pdf_preview_kaizen2b') %>?file=<%= CGI.escape(download_named_attachment_path(@attachment, @attachment.filename)) %>"
     width="100%" height="100%" style="border:none">
   </iframe>
 </div>


### PR DESCRIPTION
## Summary
- point PDF viewer iframe to `download_named_attachment_path`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f950c6710832f977590044ad9fc79