### PR TITLE
Add tests for AttachmentsControllerPatch

### DIFF
--- a/test/fixtures/attachments.yml
+++ b/test/fixtures/attachments.yml
@@ -1,0 +1,12 @@
+pdf_attachment:
+  id: 100
+  container_id: 1
+  container_type: 'Project'
+  filename: 'sample.pdf'
+  disk_filename: 'sample.pdf'
+  filesize: 1024
+  content_type: 'application/pdf'
+  digest: 'abc123'
+  downloads: 0
+  author_id: 1
+  created_on: <%%= Time.now %%>

--- a/test/functional/attachments_controller_patch_test.rb
+++ b/test/functional/attachments_controller_patch_test.rb
@@ -1,0 +1,14 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class AttachmentsControllerPatchTest < ActionController::TestCase
+  fixtures :attachments
+
+  def setup
+    @controller = AttachmentsController.new
+  end
+
+  def test_show_renders_pdf_view_for_pdf
+    get :show, params: { id: attachments(:pdf_attachment).id }
+    assert_template 'pdf_view'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path(File.dirname(__FILE__) + '/../../../../test/test_helper')


### PR DESCRIPTION
## Summary
- add functional test covering the PDF preview
- add fixture for sample PDF attachment
- include basic test helper

## Testing
- `bundle exec rake test TEST=test/functional/attachments_controller_patch_test.rb` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_687f9519e64c832fb43044a459739941