### PR TITLE
Fix infinite recursion in AttachmentsControllerPatch

### DIFF
--- a/app/controllers/attachments_controller_patch.rb
+++ b/app/controllers/attachments_controller_patch.rb
@@ -1,14 +1,15 @@
 module AttachmentsControllerPatch
   def self.included(base)
     base.class_eval do
-      alias_method :download_attachment_orig, :download
+      # Guardamos el método original para poder invocarlo cuando no es un PDF
+      alias_method :show_without_pdf_preview, :show
 
-      # interceptamos la acción show
+      # Interceptamos la acción "show" para mostrar una vista previa
       def show
         if @attachment.filename =~ /\.(pdf)\z/i
           render :pdf_view and return
         else
-          download_attachment_orig
+          show_without_pdf_preview
         end
       end
     end


### PR DESCRIPTION
## Summary
- avoid recursion when non-PDF attachments are accessed by aliasing the original `show`

## Testing
- `ruby -Itest test/functional/attachments_controller_patch_test.rb` *(fails: cannot load such file -- /test/test_helper)*

------
https://chatgpt.com/codex/tasks/task_e_687a94c00b74832f81d9de9a6523120c